### PR TITLE
Enhanced performance: Next Link instead of basic 'a href'

### DIFF
--- a/app/jobs/[slug]/page.tsx
+++ b/app/jobs/[slug]/page.tsx
@@ -1,5 +1,5 @@
+import Link from 'next/link'
 import styles from '../../page.module.css'
-
 import { getJobs } from '../../../db/data-store';
 
 interface Props {
@@ -28,7 +28,7 @@ export default async function Job({ params }: Props) {
         <div style={{ marginBottom: '50px'}}>
           {job.description}
         </div>
-        <a href={'/'}>Go Back</a>
+        <Link href={'/'}>Go Back</Link>
       </main>
     </div>
   )

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import styles from './page.module.css'
 import { getJobs } from '../db/data-store';
 
@@ -18,7 +19,7 @@ export default async function Home() {
                 <div>{job.description}</div>
               </div>
               <div>
-                <a href={`jobs/${job.slug}`}>View Job</a>
+                <Link href={`jobs/${job.slug}`}>View Job</Link>
               </div>
               <hr/>
             </div>


### PR DESCRIPTION
Included the NextJS Link component for the page files in app and job/[slug]:
```import Link from 'next/link'```

app\page.tsx -> line 22
```<a href={`jobs/${job.slug}`}>View Job</a>```
to:
```<Link href={`jobs/${job.slug}`}>View Job</Link>```

and

jobs[slug]\page.tsx -> line 32
```<a href={'/'}>Go Back</a>```
to:
```<Link href={'/'}>Go Back</Link>```

The loading of those targets will be done on page load, providing even more performance for the website!
